### PR TITLE
docs: Fix broken links and migrate Vert.x from RC to stable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ The code of the _microservice_ project contains Maven and Gradle build files tha
 The project depends on:
 
 * https://vertx.io/docs/vertx-core/java[`Vert.x Core`]
-* https://vertx.io/docs/5.0.0.CR2/vertx-service-resolver/java/[`Vert.x Service Resolver`]
+* https://vertx.io/docs/vertx-service-resolver/java/[`Vert.x Service Resolver`]
 
 The Service Resolver library is a plugin that lets Vert.x clients call services using logical service names instead of network addresses.
 The service resolver is also capable of performing client side load balancing with the usual strategies.
@@ -138,10 +138,10 @@ include::src/main/java/io/vertx/howtos/clientsidelb/MicroServiceVerticle.java[ta
 ----
 endif::env-github[]
 
-Finally let's have a look at service request handling.
+Finally, let's have a look at service request handling.
 
-First we create an HTTP server request to the back-end server.
-Instead of passing the back-end server socket address, we use instead the logical service address, which is the name of the service in Kubernetes (`hello-node`).
+First, we create an HTTP server request to the back-end server.
+Instead of passing the back-end server's socket address, we use the logical service address, which is the name of the service in Kubernetes (`hello-node`).
 
 ifdef::env-github[]
 link:src/main/java/io/vertx/howtos/clientsidelb/MicroServiceVerticle.java[MicroServiceVerticle]
@@ -362,9 +362,9 @@ changed.
 
 You can go beyond and implement the following features
 
-* Use different load-balancing https://vertx.io/docs/5.0.0.CR2/vertx-core/java/#_client_side_load_balancing[strategies]
-* Come up with your own https://vertx.io/docs/5.0.0.CR2/apidocs/io/vertx/core/net/endpoint/LoadBalancer.html[load-balancer] implementation
-* The microservice could interact with a https://vertx.io/docs/5.0.0.CR2/vertx-grpc/java/#_client_side_load_balancing[gRPC service] instead of a generic HTTP server
+* Use different load-balancing https://vertx.io/docs/vertx-core/java/#_client_side_load_balancing[strategies]
+* Come up with your own https://vertx.io/docs/apidocs/io/vertx/core/net/endpoint/LoadBalancer.html[load-balancer] implementation
+* The microservice could interact with a https://vertx.io/docs/vertx-grpc/java/#_client_side_load_balancing[gRPC service] instead of a generic HTTP server
 
 == Summary
 
@@ -376,6 +376,6 @@ This document covered:
 == See also
 
 * https://github.com/GoogleContainerTools/jib/[`Containerization with Jib`]
-* https://vertx.io/docs/5.0.0.CR2/vertx-core/java/#_client_side_load_balancing[Client side load balancing with Vert.x HTTP client]
+* https://vertx.io/docs/vertx-core/java/#_client_side_load_balancing[Client side load balancing with Vert.x HTTP client]
 * https://vertx.io/docs/vertx-service-resolver/java/#_configuring_for_kubernetes[Vert.x service resolver for Kubernetes]
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
   mavenCentral()
 }
 
-val vertxVersion = "5.0.0.CR2"
+val vertxVersion = "5.0.5"
 val verticle = "io.vertx.howtos.clientsidelb.MicroServiceVerticle"
 
 dependencies {

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <vertx.version>5.0.0.CR2</vertx.version>
+    <vertx.version>5.0.5</vertx.version>
 
     <main.verticle>io.vertx.howtos.clientsidelb.MicroServiceVerticle</main.verticle>
     <launcher.class>io.vertx.launcher.application.VertxApplication</launcher.class>

--- a/src/main/java/io/vertx/howtos/clientsidelb/MicroServiceVerticle.java
+++ b/src/main/java/io/vertx/howtos/clientsidelb/MicroServiceVerticle.java
@@ -17,7 +17,7 @@ public class MicroServiceVerticle extends VerticleBase {
   public Future<?> start() {
 
     // tag::resolver[]
-    AddressResolver resolver = KubeResolver.create(new KubeResolverOptions());
+    AddressResolver<ServiceAddress> resolver = KubeResolver.create(new KubeResolverOptions());
     // end::resolver[]
 
     // tag::load-balancer[]
@@ -54,7 +54,7 @@ public class MicroServiceVerticle extends VerticleBase {
     fut.compose(r -> r.send()
         .expecting(HttpResponseExpectation.SC_OK)
         .compose(resp -> resp.body())
-        .map(body -> "Response of pod " + r.connection().remoteAddress() + ": " + body + "\n"))
+        .map(body -> "Hello from:" + r.connection().remoteAddress() + " with: " + body + "\n"))
       .onSuccess(res -> {
         request.response()
           .putHeader("content-type", "text/plain")


### PR DESCRIPTION
- Fixed links that were causing "404 This page could not be found" errors
- Upgraded Vert.x from `5.0.0.CR2` to latest stable version `5.0.5`  in both Maven and Gradle
- Added small grammar and punctuation improvements